### PR TITLE
smarti39 June 12

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -5,16 +5,28 @@
 
 #include <string>
 
+// similarity threshold value used to determine a match between vectors
+const double DELTA = 0.85;
+
 // dimension (length) of inputted query / database vectors
 const int VECTOR_DIM = 512;
 
 // Default full-sized input source, 1 query vector and 10,000 database vectors
 const std::string BACKEND_VECTORS_FILE = "input/large.dat";
 
+const std::string DATAFOLDER = "serial";
+
 // Number of threads used in multithreaded sections
 const int RECEIVER_NUM_CORES = 4;
 const int SENDER_NUM_CORES = 4;
 
+// exponent used in alpha-norm approximation of max values, invokes a mult. depth of alpha
+const int ALPHA = 2;
+
 // Number of iterations of Newton's Method used by the secure-preprocessing receiver
-// Results in a multiplicative depth of (3i + 1)
-const int NEWTONS_ITERATIONS = 3;
+// Results in a multiplicative depth of 3i
+const int NEWTONS_ITERATIONS = 0;
+
+// Number of times the sign-approximating polynomial should be composed with itself, increasing accuracy
+// Results in a multiplicative depth of 4i
+const int SIGN_COMPOSITIONS = 4;

--- a/include/openFHE_wrapper.h
+++ b/include/openFHE_wrapper.h
@@ -2,13 +2,26 @@
 
 #pragma once
 
+#include "config.h"
 #include "openfhe.h"
 
 using namespace std;
 using namespace lbcrypto;
 
 namespace OpenFHEWrapper {
+int computeMultDepth();
+
 void printSchemeDetails(CCParams<CryptoContextCKKSRNS> parameters, CryptoContext<DCRTPoly> cc);
 
+Ciphertext<DCRTPoly> binaryRotate(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, int factor);
 
+Ciphertext<DCRTPoly> sign(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt);
+
+Ciphertext<DCRTPoly> sumAllSlots(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt);
+
+Ciphertext<DCRTPoly> approxInverseRoot(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, Ciphertext<DCRTPoly> initial);
+
+Ciphertext<DCRTPoly> normalizeVector(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, int dimension, double initialSlope, double initialIntercept);
+
+Ciphertext<DCRTPoly> alphaNorm(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, int alpha, int partitionLen);
 }

--- a/include/receiver.h
+++ b/include/receiver.h
@@ -21,13 +21,22 @@ public:
 
   // utility functions for computing cosine similarity
   double plaintextMagnitude(vector<double> x);
+
   double plaintextInnerProduct(vector<double> x, vector<double> y);
+  
   std::vector<double> plaintextNormalize(vector<double> x);
+  
   double plaintextCosineSim(vector<double> x, vector<double> y);
+  
   Ciphertext<DCRTPoly> encryptQuery(vector<double> query);
+  
   vector<Ciphertext<DCRTPoly>> encryptDB(vector<vector<double>> database);
+  
   vector<Plaintext> decryptSimilarity(vector<Ciphertext<DCRTPoly>> cosineCipher);
+
   vector<double> decryptMergedScores(vector<Ciphertext<DCRTPoly>> mergedCipher);
+
+  double decryptMembershipQuery(Ciphertext<DCRTPoly> membershipCipher);
 
 protected:
   // some protected members here -- inherited by subclass

--- a/include/sender.h
+++ b/include/sender.h
@@ -24,7 +24,12 @@ public:
                     vector<Ciphertext<DCRTPoly>> database);
 
   vector<Ciphertext<DCRTPoly>>
-  mergeScores(vector<Ciphertext<DCRTPoly>> similarityCipher);
+  mergeScores(vector<Ciphertext<DCRTPoly>> similarityCipher, int numScores);
+
+  vector<Ciphertext<DCRTPoly>>
+  approximateMax(vector<Ciphertext<DCRTPoly>> similarityCipher, int alpha, int partitionLen);
+
+  Ciphertext<DCRTPoly> membershipQuery(vector<Ciphertext<DCRTPoly>> similarityCipher);
 
 private:
   // some private members here

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,12 @@
 #include "openfhe.h"
 #include <iostream>
 
+// header files needed for serialization -- discuss how to implement
+#include "ciphertext-ser.h"
+#include "cryptocontext-ser.h"
+#include "key/key-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
+
 using namespace lbcrypto;
 using namespace std;
 
@@ -29,9 +35,10 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  // plaintext preprocessing currently requires multDepth = 3 -> batchSize = 8192
-  // secure preprocessing currently requires multDepth = 15 -> batchSize = 32768
-  uint32_t multDepth = 3;
+  // TODO: check / update these vals
+  // plaintext preprocessing currently requires multDepth = 8 -> batchSize = 8192
+  // secure preprocessing currently requires multDepth = 20 -> batchSize = 32768
+  uint32_t multDepth = OpenFHEWrapper::computeMultDepth();
   CCParams<CryptoContextCKKSRNS> parameters;
   parameters.SetSecurityLevel(HEStd_128_classic);
   parameters.SetMultiplicativeDepth(multDepth);
@@ -42,32 +49,39 @@ int main(int argc, char *argv[]) {
   cc->Enable(KEYSWITCH);
   cc->Enable(LEVELEDSHE);
   cc->Enable(ADVANCEDSHE);
-
+  
   int batchSize = cc->GetEncodingParams()->GetBatchSize();
-  int vectorsPerBatch = int(batchSize / VECTOR_DIM);
 
   // OpenFHEWrapper::printSchemeDetails(parameters, cc);
-  cout << "[main.cpp]\tCKKS scheme set up (depth = " << multDepth << ", batch size = " << batchSize << ")..." << endl;
+  cout << "[main.cpp]\tCKKS scheme set up (depth = " << multDepth << ", batch size = " << batchSize << ")" << endl;
 
+  cout << "[main.cpp]\tGenerating key pair... " << flush;
   auto keyPair = cc->KeyGen();
   auto pk = keyPair.publicKey;
   auto sk = keyPair.secretKey;
-  cc->EvalMultKeyGen(sk);
-  cc->EvalSumKeyGen(sk);
+  cout << "done" << endl;
 
-  // these specific rotations needed for merge operation
-  vector<int> rotationFactors;
-  for(int i = 1; i*vectorsPerBatch < batchSize; i++) {
-    rotationFactors.push_back(i*-vectorsPerBatch);
+
+  vector<int> binaryRotationFactors;
+  for(int i = 1; i < batchSize; i *= 2) {
+    binaryRotationFactors.push_back(i);
+    binaryRotationFactors.push_back(-i);
   }
-  
-  for(int i = (VECTOR_DIM - 1); i < batchSize; i *= 2) {
-    rotationFactors.push_back(i);
-  }
-  cc->EvalRotateKeyGen(sk, rotationFactors);
-  cout << "[main.cpp]\tCKKS keys generated..." << endl;
+
+  cout << "[main.cpp]\tGenerating mult keys... " << flush;
+  cc->EvalMultKeyGen(sk);
+  cout << "done" << endl;
+
+  cout << "[main.cpp]\tGenerating sum keys... " << flush;
+  cc->EvalSumKeyGen(sk);
+  cout << "done" << endl;
+
+  cout << "[main.cpp]\tGenerating rotation keys... " << flush;
+  cc->EvalRotateKeyGen(sk, binaryRotationFactors);
+  cout << "done" << endl;
 
   // Read in vectors from file
+  cout << "[main.cpp]\tReading in vectors from file... " << flush;
   int numVectors;
   fileStream >> numVectors;
 
@@ -85,7 +99,7 @@ int main(int argc, char *argv[]) {
     }
   }
   fileStream.close();
-  cout << "[main.cpp]\tVectors read in from file..." << endl;
+  cout << "done" << endl;
 
   // Initialize receiver and sender objects -- only the receiver possesses the secret key
   Receiver receiver(cc, pk, sk, numVectors);
@@ -115,6 +129,12 @@ int main(int argc, char *argv[]) {
     cout << "Merged:  \t" << mergedValues[i] << endl;
     cout << endl;
   }
+
+  // Run membership scenario upon similarity scores
+  Ciphertext<DCRTPoly> membershipCipher =
+      sender.membershipQuery(similarityCipher);
+  double membershipResults = receiver.decryptMembershipQuery(membershipCipher);
+  cout << endl << "Membership Query: there exists " << membershipResults << " match(es) between the query and the database" << endl;
 
   return 0;
 }

--- a/src/openFHE_wrapper.cpp
+++ b/src/openFHE_wrapper.cpp
@@ -1,5 +1,33 @@
 #include "../include/openFHE_wrapper.h"
 
+// computes required multiplicative depth based on parameters from config.h
+int OpenFHEWrapper::computeMultDepth() {
+  // for initial similarity computation
+  int depth = 1;
+
+  // for the merge operation upon the similarity scores
+  depth += 2;
+
+  // for computing max approximations
+  depth += ALPHA;
+
+  // for merge operation upon the max approximations
+  depth += 2;
+
+  // for approximating inverse magnitude
+  // depth += 3*NEWTONS_ITERATIONS;
+
+  // each composition of the sign(x) polynomial requires a depth of 4
+  depth += 4*SIGN_COMPOSITIONS;
+
+  // TODO: determine untracked depth
+  depth += 2;
+
+  return depth;
+}
+
+
+
 void OpenFHEWrapper::printSchemeDetails(CCParams<CryptoContextCKKSRNS> parameters, CryptoContext<DCRTPoly> cc) {
   cout << "batch size: " << cc->GetEncodingParams()->GetBatchSize() << endl;
   cout << endl;
@@ -12,4 +40,121 @@ void OpenFHEWrapper::printSchemeDetails(CCParams<CryptoContextCKKSRNS> parameter
   cout << "noise estimate: " << parameters.GetNoiseEstimate() << endl;
   cout << "multiplicative depth: " << parameters.GetMultiplicativeDepth() <<
   endl; cout << "noise level: " << parameters.GetNoiseEstimate() << endl;
+}
+
+
+
+// performs any rotation on a ciphertext using 2log2(batchsize) rotation keys and (1/2)log2(batchsize) rotations
+Ciphertext<DCRTPoly> OpenFHEWrapper::binaryRotate(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, int factor) {
+  int batchSize = cc->GetEncodingParams()->GetBatchSize();
+
+  vector<int> neededRotations;
+  int factorSign;
+  int binaryCounter;
+  int currentRotation;
+
+  while(factor != 0) {
+    factorSign = factor / abs(factor);
+
+    binaryCounter = pow(2, round(log2(abs(factor))));
+    currentRotation = (binaryCounter * factorSign) % batchSize;
+    if(currentRotation != 0) {
+      neededRotations.push_back(binaryCounter * factorSign);
+    }
+
+    factor -= binaryCounter * factorSign;
+  }
+
+  for(long unsigned int i = 0; i < neededRotations.size(); i++) {
+    ctxt = cc->EvalRotate(ctxt, neededRotations[i]);
+  }
+
+  return ctxt;
+}
+
+
+
+// Approximating polynomial f4 determined from JH Cheon, 2019/1234
+// TODO: properly cite
+Ciphertext<DCRTPoly> OpenFHEWrapper::sign(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> x) {
+  
+  vector<double> coefficients({ 0.0, 
+                                315.0 / 128.0,  
+                                0.0, 
+                                -420.0 / 128.0, 
+                                0.0, 
+                                378.0 / 128.0,
+                                0.0, 
+                                -180.0 / 128.0,
+                                0.0,
+                                35.0 / 128.0});
+
+  for(int i = 0; i < SIGN_COMPOSITIONS; i++) {
+    x = cc->EvalPoly(x, coefficients);
+  }
+
+  return cc->EvalMult(0.5, cc->EvalAdd(x, 1.0));
+}
+
+// Sets every slot in the ciphertext equal to the sum of all slots
+Ciphertext<DCRTPoly> OpenFHEWrapper::sumAllSlots(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt) {
+  int batchSize = cc->GetEncodingParams()->GetBatchSize();
+  Ciphertext<DCRTPoly> temp;
+  for(int i = 1; i < batchSize; i *= 2) {
+    temp = binaryRotate(cc, ctxt, i);
+    ctxt = cc->EvalAdd(ctxt, temp);
+  }
+  return ctxt;
+}
+
+// Uses Newton's Method to approximate the inverse square root of the slots of a ciphertext
+// Requires good initial approximation
+Ciphertext<DCRTPoly>
+OpenFHEWrapper::approxInverseRoot(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, Ciphertext<DCRTPoly> initial) {
+
+  Ciphertext<DCRTPoly> bn = ctxt;
+  Ciphertext<DCRTPoly> fn = initial;
+  Ciphertext<DCRTPoly> yn = fn;
+
+  // Perform Newton's method to approximate inverse magnitude of ctxt
+  // The multiplicative depth for i iterations is 3i+1
+  for (int i = 0; i < NEWTONS_ITERATIONS; i++) {
+    // b(n+1) = b(n) * f(n)^2
+    bn = cc->EvalMult(bn, fn);
+    bn = cc->EvalMult(bn, fn);
+
+    // f(n+1) = (1/2) * (3 - b(n))
+    fn = cc->EvalSub(3.0, bn);
+    fn = cc->EvalMult(fn, 0.5);
+
+    // y(n+1) = y(n) * f(n)
+    yn = cc->EvalMult(yn, fn);
+  }
+
+  return yn;
+}
+
+
+
+Ciphertext<DCRTPoly>
+OpenFHEWrapper::normalizeVector(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, int dimension, double initialSlope, double initialIntercept) {
+
+  Ciphertext<DCRTPoly> selfInnerProduct = cc->EvalInnerProduct(ctxt, ctxt, dimension);
+  Ciphertext<DCRTPoly> initialGuess = cc->EvalAdd(cc->EvalMult(selfInnerProduct, initialSlope), initialIntercept);
+  Ciphertext<DCRTPoly> normalizationFactor = approxInverseRoot(cc, selfInnerProduct, initialGuess);
+  
+  return cc->EvalMult(ctxt, normalizationFactor);
+}
+
+
+
+Ciphertext<DCRTPoly> OpenFHEWrapper::alphaNorm(CryptoContext<DCRTPoly> cc, Ciphertext<DCRTPoly> ctxt, int alpha, int partitionLen) {
+  Ciphertext<DCRTPoly> result = ctxt;
+
+  for(int i = 0; i < alpha; i++) {
+    result = cc->EvalMult(result, result);
+  }
+  result = cc->EvalInnerProduct(result, ctxt, partitionLen);
+
+  return result;
 }

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -5,9 +5,12 @@ Sender::Sender(CryptoContext<DCRTPoly> ccParam, PublicKey<DCRTPoly> pkParam,
                int vectorParam)
     : cc(ccParam), pk(pkParam), numVectors(vectorParam) {}
 
+
+
 vector<Ciphertext<DCRTPoly>>
 Sender::computeSimilarity(Ciphertext<DCRTPoly> query,
                           vector<Ciphertext<DCRTPoly>> database) {
+  cout << "[sender.cpp]\tComputing similarity scores... " << flush;
   vector<Ciphertext<DCRTPoly>> similarityCipher(database.size());
 
   // embarrassingly parallel
@@ -15,20 +18,23 @@ Sender::computeSimilarity(Ciphertext<DCRTPoly> query,
   for (unsigned int i = 0; i < database.size(); i++) {
     similarityCipher[i] = cc->EvalInnerProduct(query, database[i], VECTOR_DIM);
   }
-  cout << "[sender.cpp]\tSimilarity scores computed..." << endl;
 
-  return mergeScores(similarityCipher);
+  cout << "done" << endl;
+  return mergeScores(similarityCipher, numVectors);
 }
+
+
 
 // This implementation requires only two ciphertext multiplications per similarity ciphertext
 // However, approach only works if VECTOR_DIM >= (batchSize / VECTOR_DIM)
 // In our current case, VECTOR_DIM = 512 and (batchSize / VECTOR_DIM) = 16, therefore okay
 // Essentially this needs to be modified if batchSize exceeds 262,144
-vector<Ciphertext<DCRTPoly>> Sender::mergeScores(vector<Ciphertext<DCRTPoly>> similarityCipher) {
+vector<Ciphertext<DCRTPoly>> Sender::mergeScores(vector<Ciphertext<DCRTPoly>> similarityCipher, int numScores) {
+  cout << "[sender.cpp]\tMerging similarity scores... " << flush;
 
   int batchSize = cc->GetEncodingParams()->GetBatchSize();
   int scoresPerBatch = int(batchSize / VECTOR_DIM);
-  int ciphersNeeded = 1 + int(numVectors / batchSize);
+  int ciphersNeeded = 1 + int(numScores / batchSize);
   int reductionFactor = batchSize / scoresPerBatch;
 
   // mergedCipher is the vector of ciphertexts to be returned
@@ -68,7 +74,7 @@ vector<Ciphertext<DCRTPoly>> Sender::mergeScores(vector<Ciphertext<DCRTPoly>> si
 
       // perform rotations and additions to move similarity scores to front of ciphertext
       for(int rotationFactor = VECTOR_DIM - 1; rotationFactor < batchSize; rotationFactor *= 2) {
-        tempCipher = cc->EvalRotate(currentBatchCipher, rotationFactor);
+        tempCipher = OpenFHEWrapper::binaryRotate(cc, currentBatchCipher, rotationFactor); // cc->EvalRotate(currentBatchCipher, rotationFactor);
         currentBatchCipher = cc->EvalAdd(currentBatchCipher, tempCipher);
       }
 
@@ -79,12 +85,56 @@ vector<Ciphertext<DCRTPoly>> Sender::mergeScores(vector<Ciphertext<DCRTPoly>> si
       if(j == 0) {
         mergedCipher[i] = currentBatchCipher;
       } else {
-        currentBatchCipher = cc->EvalRotate(currentBatchCipher, j*-scoresPerBatch);
+        currentBatchCipher = OpenFHEWrapper::binaryRotate(cc, currentBatchCipher, j*-scoresPerBatch); // cc->EvalRotate(currentBatchCipher, j*-scoresPerBatch);
         mergedCipher[i] = cc->EvalAdd(mergedCipher[i], currentBatchCipher);
       }
     }
   }
 
-  cout << "[sender.cpp]\tSimilarity scores merged..." << endl;
+  cout << "done" << endl;
   return mergedCipher;
+}
+
+
+
+vector<Ciphertext<DCRTPoly>> Sender::approximateMax(vector<Ciphertext<DCRTPoly>> similarityCipher, int alpha, int partitionLen) {
+  cout << "[sender.cpp]\tApproximating maximum scores... " << flush;
+  vector<Ciphertext<DCRTPoly>> maxCipher = similarityCipher;
+
+  #pragma omp parallel for num_threads(SENDER_NUM_CORES)
+  for(long unsigned int i = 0; i < similarityCipher.size(); i++) {
+    maxCipher[i] = OpenFHEWrapper::alphaNorm(cc, maxCipher[i], alpha, partitionLen);
+  }
+
+  cout << "done" << endl;
+  return mergeScores(maxCipher, (numVectors / partitionLen));
+}
+
+
+
+Ciphertext<DCRTPoly>
+Sender::membershipQuery(vector<Ciphertext<DCRTPoly>> similarityCipher) {
+
+  // Sender performs alpha-norm / merge operation to reduce number of scores by factor of 512
+  // TODO: experiment with other partition lengths, VECTOR_DIM works with merge operation
+  vector<Ciphertext<DCRTPoly>> maxCipher =
+      approximateMax(similarityCipher, ALPHA, VECTOR_DIM);
+
+  // TODO: parallelize this
+  double adjustedThreshold = pow(DELTA, ALPHA);
+
+  #pragma omp parallel for num_threads(SENDER_NUM_CORES)
+  for(long unsigned int i = 0; i < maxCipher.size(); i++) {
+    maxCipher[i] = cc->EvalAdd(maxCipher[i], -adjustedThreshold);
+    maxCipher[i] = OpenFHEWrapper::sign(cc, maxCipher[i]);
+    // maxCipher[i] = OpenFHEWrapper::normalizeVector(cc, maxCipher[i], 1, 0.1, -0.1/512.0);
+    maxCipher[i] = OpenFHEWrapper::sumAllSlots(cc, maxCipher[i]);
+  }
+
+  // combine sums from all ciphertexts into first ciphertext, only return the first
+  for(long unsigned int i = 1; i < maxCipher.size(); i++) {
+    maxCipher[0] = cc->EvalAdd(maxCipher[0], maxCipher[i]);
+  }
+
+  return maxCipher[0];
 }


### PR DESCRIPTION
 - Implemented private membership scenario
 - Receiver obtains a ciphertext containing the number of matches between the query and the database
 - If we want to obscure the exact number in favor of a boolean, a random noise scalar must be added at the end of the sender function
 - Need to parallelize the score merge wrapper function
 - Need to test normalization function in case of multiple matches per row